### PR TITLE
chore: remove Trivy security scanner from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,20 +393,6 @@ jobs:
         echo "Checking if our image exists:"
         docker inspect otel-core-example:pr-${{ github.event.pull_request.number }}
 
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
-      with:
-        image-ref: otel-core-example:pr-${{ github.event.pull_request.number }}
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        exit-code: '0'
-
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4
-      if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
-      with:
-        sarif_file: 'trivy-results.sarif'
-
   docker-publish:
     runs-on: ubuntu-latest
     needs: [build, test, code-quality]


### PR DESCRIPTION
## Summary

- Removes \`aquasecurity/trivy-action\` from CI workflows due to the Trivy supply chain security incident
- Removes associated \`github/codeql-action/upload-sarif\` step (was only used to upload Trivy SARIF results)

## References

https://github.com/aquasecurity/trivy-action/issues/457

Made with [Cursor](https://cursor.com)